### PR TITLE
Makefile: darwin: don't set install_name to $(shell pwd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ FULL_LIB_NAME = $(VERSION_LIB_NAME).$(MINOR_VERSION).$(PATCH_LEVEL)
 ifeq ($(shell uname -s), Darwin)
 	LIB_NAME = libodpic.dylib
 	LIB_OUT_OPTS = -dynamiclib \
-		-install_name $(shell pwd)/$(LIB_DIR)/$(LIB_NAME) \
+		-install_name $(LIB_DIR)/$(LIB_NAME) \
 		-o $(LIB_DIR)/$(FULL_LIB_NAME)
 else
 	LIB_NAME = libodpic.so


### PR DESCRIPTION
doing so introduces a dependency from libodpic.dylib to the ephemeral sandbox path during the build of libodpic.dylib:

```
result/lib/libodpic.dylib:
	/private/tmp/nix-build-odpic-2.4.0.drv-0/odpi-2.4.0/lib/libodpic.dylib (compatibility version 0.0.0, current version 0.0.0)
	/nix/store/xn55wd7nimdi085kji54mrrqqnqvcasz-Libsystem-osx-10.11.6/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

Instead, keep the path relative.