### PR TITLE
oranif  repo org change

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Third-party Drivers:
 * [ruby-ODPI ](https://github.com/kubo/ruby-odpi) Ruby Interface.
 * [rust-oracle ](https://github.com/kubo/rust-oracle) Driver for Rust.
 * [Oracle.jl](https://github.com/felipenoris/Oracle.jl) Driver for Julia.
-* [oranif](https://github.com/K2InformaticsGmbH/oranif) Driver for Erlang.
+* [oranif](https://github.com/KonnexionsGmbH/oranif) Driver for Erlang.
 * [nimodpi](https://github.com/mikra01/nimodpi) Driver for Nim.
 
 ## License


### PR DESCRIPTION
Hi,

The oranif (erlang driver) has new home now!

Moved from https://github.com/K2InformaticsGmbH/oranif (deprecated and currently Archived) to https://github.com/KonnexionsGmbH/oranif

This PR need not be accepted/merge as per the policy (so please feel free to close it). This just to show quickly what has changed. The https://github.com/K2InformaticsGmbH/oranif may be deleted in near future too!

TIA